### PR TITLE
Update README due to missing rainbow dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All this combined with the simplicity of _Ruby and its gems_, some reinvented _p
 You must have the following tools installed to use this boilerplate:
 
 -   [Bundler](https://bundler.io)
+-   [Rainbow](https://github.com/sickill/rainbow) - `gem install rainbow`
 -   [Node](https://nodejs.org) (> v4)
 -   [Yarn](https://yarnpkg.com)
 


### PR DESCRIPTION
Install fails unless rainbow is installed. You may consider swapping out that library to avoid the dependency issue altogether, but otherwise here is an update to the README.